### PR TITLE
Upgrade Spring Boot to 4.0.1 and adapt tests/migrations for compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-webmvc-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
-    testImplementation "org.junit.platform:junit-platform-commons:6.0.1"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:6.0.1"
+    testImplementation "org.junit.platform:junit-platform-commons:$junitVersion"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitVersion"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlinVersion = '2.1.21'
-        springBootVersion = '3.4.1'
+        springBootVersion = '4.0.1'
         jacksonVersion = '2.12.3'
         springdocVersion = '2.6.0'
         exposedVersion = '0.52.0'
@@ -9,7 +9,7 @@ buildscript {
         jwkSetVersion = '5.1'
         auth0Version = '3.14.0'
         flywayVersion = '10.17.2'
-        junitVersion = '5.11.3'
+        junitVersion = '6.0.1'
         mockkVersion = '1.13.3'
         springMockkVersion = '3.0.1'
         striktVersion = '0.31.0'
@@ -69,6 +69,7 @@ dependencies {
     implementation 'org.springframework.data:spring-data-commons'
     implementation 'com.mysql:mysql-connector-j'
 
+    implementation 'org.springframework.boot:spring-boot-flyway'
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}"
 
     implementation "org.jetbrains.exposed:exposed-core:$exposedVersion"
@@ -90,10 +91,11 @@ dependencies {
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-webmvc-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
-    testImplementation "org.junit.platform:junit-platform-commons:1.11.3"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.11.3"
+    testImplementation "org.junit.platform:junit-platform-commons:6.0.1"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:6.0.1"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"

--- a/src/main/kotlin/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.kt
+++ b/src/main/kotlin/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.kt
@@ -1,0 +1,8 @@
+package org.springframework.boot.autoconfigure.jdbc
+
+/**
+ * Compatibility shim for libraries that still reference the Spring Boot 3.x
+ * auto-configuration class name. Spring Boot 4.x relocated this type under
+ * org.springframework.boot.jdbc.autoconfigure.
+ */
+class DataSourceAutoConfiguration

--- a/src/main/resources/db/migration/h2/V1__initial.sql
+++ b/src/main/resources/db/migration/h2/V1__initial.sql
@@ -4,8 +4,8 @@ create table recipes (
   name varchar(255) not null,
   servings integer not null,
 
-  created_at datetime not null default CURRENT_TIMESTAMP,
-  updated_at datetime not null default CURRENT_TIMESTAMP
+  created_at timestamp not null default CURRENT_TIMESTAMP,
+  updated_at timestamp not null default CURRENT_TIMESTAMP
 );
 
 create table ingredients (
@@ -14,8 +14,8 @@ create table ingredients (
   quantity integer not null,
   unit varchar(8) not null,
 
-  created_at datetime not null default CURRENT_TIMESTAMP,
-  updated_at datetime not null default CURRENT_TIMESTAMP,
+  created_at timestamp not null default CURRENT_TIMESTAMP,
+  updated_at timestamp not null default CURRENT_TIMESTAMP,
 
   recipe_id bigint,
   foreign key (recipe_id) references  recipes (id)
@@ -26,8 +26,8 @@ create table steps (
   description text not null,
   duration integer not null,
 
-  created_at datetime not null default CURRENT_TIMESTAMP,
-  updated_at datetime not null default CURRENT_TIMESTAMP,
+  created_at timestamp not null default CURRENT_TIMESTAMP,
+  updated_at timestamp not null default CURRENT_TIMESTAMP,
 
   recipe_id bigint,
   foreign key (recipe_id) references  recipes (id)

--- a/src/test/kotlin/com/hceris/cookery2/recipes/RecipeRepositoryTest.kt
+++ b/src/test/kotlin/com/hceris/cookery2/recipes/RecipeRepositoryTest.kt
@@ -7,8 +7,8 @@ import com.hceris.cookery2.isRight
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
-import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import strikt.api.expectThat

--- a/src/test/kotlin/com/hceris/cookery2/recipes/RecipesControllerTest.kt
+++ b/src/test/kotlin/com/hceris/cookery2/recipes/RecipesControllerTest.kt
@@ -11,10 +11,11 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -70,23 +71,23 @@ internal class RecipesControllerTest(@Autowired val mockMvc: MockMvc) {
      }   
     """.trimIndent()
 
-    @WithMockUser(username = "dudu", authorities = ["profile", "create:recipes"])
     @Test
     fun `creates recipe`() {
         every { repository.create(any()) } returns 1
 
         mockMvc.perform(MockMvcRequestBuilders.post("/rest/recipes")
+                .with(user("dudu").authorities(SimpleGrantedAuthority("create:recipes")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(MockMvcResultMatchers.status().isCreated)
     }
 
-    @WithMockUser(username = "dudu", authorities = ["profile", "create:recipes"])
     @Test
     fun `creates throws error if invalid form was sent`() {
         every { repository.create(any()) } returns 1
 
         mockMvc.perform(MockMvcRequestBuilders.post("/rest/recipes")
+                .with(user("dudu").authorities(SimpleGrantedAuthority("create:recipes")))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(invalidJson))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest)


### PR DESCRIPTION
### Motivation
- Move the project to Spring Boot 4.x to pick up the 4.0.1 release and its improvements.
- Align test code and dependencies with Spring Boot 4 module/package changes so tests can run under Boot 4.
- Fix runtime issues caused by library relocations (Exposed) and H2/Flyway SQL incompatibilities with newer platform versions.
- Keep test behavior equivalent (security, web MVC tests) after the dependency/version upgrade.

### Description
- Bumped `springBootVersion` to `4.0.1` and updated related test/JUnit coordinates (`junitVersion` to `6.0.1`) in `build.gradle` and added `org.springframework.boot:spring-boot-flyway` and `org.springframework.boot:spring-boot-webmvc-test` dependencies.
- Updated test imports and code to match Spring Boot 4 package layout by replacing `org.springframework.boot.autoconfigure.*` imports with the relocated packages and switching `WebMvcTest` import to `org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest`.
- Added a small compatibility shim `org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.kt` to satisfy libraries (Exposed) that reference the old 3.x class name.
- Fixed H2 Flyway migrations by replacing `datetime` with H2-compatible `timestamp` in `src/main/resources/db/migration/h2/V1__initial.sql` and adjusted test security setup to use `SecurityMockMvcRequestPostProcessors.user` with authorities.

### Testing
- Ran `./gradlew test` and the full test suite completed successfully (all tests passed).
- Ran `./gradlew detekt` which failed due to a Kotlin/detekt version mismatch: "detekt was compiled with Kotlin 1.9.23 but is currently running with 2.1.21." (still failing).
- Verified that Flyway migrations run in the test environment after SQL fixes and that controller tests exercising security now pass.
- No other automated checks were modified; build and tests were executed in CI-local environment as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae24e63388327a0554d48211cda15)